### PR TITLE
fix percent, fix runlevel

### DIFF
--- a/src/main/active_db/percent.c
+++ b/src/main/active_db/percent.c
@@ -46,6 +46,7 @@ int initng_active_db_percent_started(void)
 		assert(current->current_state);
 
 		switch (GET_STATE(current)) {
+		case Is_NEW:
 		case IS_STARTING:
 			starting++;
 			break;

--- a/src/main/interrupt/check_sys_state.c
+++ b/src/main/interrupt/check_sys_state.c
@@ -42,7 +42,7 @@ void check_sys_state_up(void)
 	/* check actives, if any has one of these status, system cant be set
 	 * to STATE_UP */
 	while_active_db(current) {
-		if (GET_STATE(current) == IS_STARTING)
+		if (GET_STATE(current) != IS_UP)
 			return;
 	}
 


### PR DESCRIPTION
Those changes fixes:
- the percent computation with the introduction of the state IS_NEW.
- the display of the 'runlevel is up' message at the end of the init sequence.